### PR TITLE
fix: replace "Quadrant Diagram" with "QuadrantDiagram"

### DIFF
--- a/src/app/component/component.route.ts
+++ b/src/app/component/component.route.ts
@@ -388,7 +388,7 @@ export const routesConfig = [
       ),
     data: {
       type: '演进中',
-      name: 'Quadrant Diagram',
+      name: 'QuadrantDiagram',
       cnName: '象限图',
       description: '象限图，根据需求对事务进行区域划分与价值排序',
       tmw: `可用于管理事务的优先级`,


### PR DESCRIPTION
Change the name of the Quadrant Diagram displayed in the left navigation("Quadrant Diagram" changed to "QuadrantDiagram") to be consistent with the other components