### PR TITLE
feat(avatar): Allow avatar to pass referrerPolicy for imgSrc

### DIFF
--- a/devui/avatar/avatar.component.html
+++ b/devui/avatar/avatar.component.html
@@ -1,6 +1,7 @@
 <img
   *ngIf="imgSrc && !isErrorImg"
   [src]="imgSrc"
+  [referrerPolicy]="referrerPolicy"
   alt=""
   (error)="showErrAvatar()"
   [ngStyle]="{

--- a/devui/avatar/avatar.component.ts
+++ b/devui/avatar/avatar.component.ts
@@ -40,6 +40,10 @@ export class AvatarComponent implements OnChanges, OnInit {
    * 自定义头像显示文字
    */
   @Input() customText: string;
+  /**
+   * 若使用图片时需要特别的 referrerPolicy
+   */
+  @Input() referrerPolicy: 'no-referrer' | 'no-referrer-when-downgrade' | 'origin' | 'origin-when-cross-origin' | 'unsafe-url' = 'no-referrer-when-downgrade';
 
   fontSize = 12;
   code: number;

--- a/devui/avatar/doc/api-cn.md
+++ b/devui/avatar/doc/api-cn.md
@@ -24,6 +24,7 @@ import { AvatarModule } from 'ng-devui/avatar';
 |  isRound   |       `boolean`        | true | 可选，是否显示为圆形头像                                                    | [头像的基础配置](demo#basic-configuration) |
 |   imgSrc   |        `string`        |  --  | 可选，传入自定义图片作为头像                                                | [头像的基础配置](demo#basic-configuration) |
 | customText |        `string`        |  --  | 可选，传入自定义显示文字                                                    | [头像的基础配置](demo#basic-configuration) |
+| referrerPolicy |        `string`        |  no-referrer-when-downgrade  | 指定在获取图像时要使用的引荐来源信息。 |   |
 
 ### 头像显示基本规则
 

--- a/devui/avatar/doc/api-en.md
+++ b/devui/avatar/doc/api-en.md
@@ -23,6 +23,7 @@ In the page:
 |      isRound     |        `boolean`        |   true | Optional. Indicating whether to display a circular avatar | [Basic Configuration](demo#basic-configuration)     |
 |      imgSrc      |         `string`        |   --   | Optional. Import a customized image as the avatar | [Basic Configuration](demo#basic-configuration) |
 |    customText    |         `string`        |   --   | Optional. Input the customized display text | [Basic Configuration](demo#basic-configuration) |
+|  referrerPolicy  |        `string`        |  no-referrer-when-downgrade  | Specifies which referrer information to use when fetching an image. |   |
 
 
 ### Basic Profile Picture Display Rules


### PR DESCRIPTION
When using some services (E.g. firebase together with google authentication), sometimes we will need a custom referrer policy.
This patch addresses it by allowing passes of the tag to the final 'img' element.